### PR TITLE
occurrence space fix; some HTML improvements

### DIFF
--- a/tei/EAC-CPF_eng_one.xml
+++ b/tei/EAC-CPF_eng_one.xml
@@ -521,7 +521,7 @@
                   Party's candidate for President, but he was defeated by Richard M. Nixon. </eac-cpf:abstract>
                <eac-cpf:p>Hubert H. Humphrey was born in Wallace, South Dakota, on May 27,
                   1911. He left South Dakota to attend the University of Minnesota but
-                  returned to South Dakota to help manage his father&#x92;s drug store early
+                  returned to South Dakota to help manage his father's drug store early
                   in the depression. He attended the Capitol College of Pharmacy in
                   Denver, Colorado, and became a register pharmacist in 1933. On
                   September 3, 1936, Humphrey married Muriel Fay Buck. He returned
@@ -536,7 +536,7 @@
                   worked at a variety of jobs. In 1945, he was elected Mayor of
                   Minneapolis and served until 1948. In 1948, at the Democratic
                   National Convention, he gained national attention when he delivered a
-                  stirring speech in favor of a strong civil rights plank in the party&#x92;s
+                  stirring speech in favor of a strong civil rights plank in the party's
                   platform. In November of 1948, Humphrey was elected to the United
                   States Senate. He served as the Senate Democratic Whip from 1961 to
                   1964.</eac-cpf:p>
@@ -544,7 +544,7 @@
                   Johnson asked the convention to select Humphrey as the Vice
                   Presidential nominee. The ticket was elected in November in a
                   Democratic landslide. In 1968, Humphrey was the Democratic
-                  Party&#x92;s candidate for President, but he was defeated narrowly by
+                  Party's candidate for President, but he was defeated narrowly by
                   Richard M. Nixon. After the defeat, Humphrey returned to Minnesota
                   to teach at the University of Minnesota and Macalester College. He
                   returned to the U.S. Senate in 1971, and he won re-election in 1976.

--- a/tei/Headingtranslation.xml
+++ b/tei/Headingtranslation.xml
@@ -11,11 +11,11 @@ type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
         <translation lang="it">Sommario</translation>
     </term>
     <term name="description">
-        <translation lang="en">Description</translation>
-        <translation lang="fr">Description</translation>
-        <translation lang="gr">Περιγραφ&#942;</translation>
-        <translation lang="de">Beschreibung</translation>
-        <translation lang="it">Descrizione</translation>
+        <translation lang="en">Description and Usage</translation>
+        <translation lang="fr">Description et Usage</translation>
+        <translation lang="gr">Περιγραφ&#942; και Χρ&#942;ση</translation>
+        <translation lang="de">Beschreibung und Verwendung</translation>
+        <translation lang="it">Descrizione e Uso</translation>
     </term>
     <term name="mayOccurWithin">
         <translation lang="en">May occur within</translation>

--- a/transformations/Taglibrary2pdf.xsl
+++ b/transformations/Taglibrary2pdf.xsl
@@ -28,7 +28,7 @@
     <xsl:variable name="currentLanguage">en</xsl:variable><!-- xml:lang from taglibrary -->
     <xsl:variable name="toctype">long</xsl:variable><!-- Used for determine style of toc Values: long | short -->
     <xsl:param name="spaceCharacter"> </xsl:param><!-- For egxml formatting -->
-        <xsl:variable name="bulletpoint">&#x2022;</xsl:variable>
+    <xsl:variable name="bulletpoint">&#x2022;</xsl:variable>
     <xsl:variable name="returntotoc">yes</xsl:variable><!--Used for creating the return to toc Values: yes | no -->
    
     <xsl:variable name="path">../images/</xsl:variable>  
@@ -853,7 +853,7 @@
     </xsl:template>
     
     <!-- Non-tokenized note divs -->
-    <xsl:template match="tei:div[@type=('summary', 'definition', 'rationale', 'creationmaintenance', 'usagenotes', 'attributeusage', 'seealso', 'datatype', 'values', 'occurrence', 'availability', 'attributeusage', 'reference', 'references')]">
+    <xsl:template match="tei:div[@type=('summary', 'definition', 'rationale', 'creationmaintenance', 'usagenotes', 'attributeusage', 'seealso', 'datatype', 'values', 'availability', 'attributeusage', 'reference', 'references')]">
         <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
             <fo:list-item>
                 <fo:list-item-label end-indent="label-end()">
@@ -914,6 +914,27 @@
         </fo:list-block>
     </xsl:template>
 
+    <!-- occurrence has some special rules, so it gets a special template -->
+    <xsl:template match="tei:div[@type='occurrence']">
+        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
+            <fo:list-item>
+                <fo:list-item-label end-indent="label-end()">
+                    <fo:block font-weight="bold">
+                        <xsl:value-of select="$occurrence"/>
+                        <xsl:text>: </xsl:text>
+                    </fo:block>
+                </fo:list-item-label>
+                <fo:list-item-body start-indent="body-start()">
+                    <fo:block>
+                        <xsl:value-of select="tei:div[@type='mandatory']/tei:p"/>
+                        <xsl:text>, </xsl:text>
+                        <xsl:value-of select="tei:div[@type='repeatable']/tei:p"/>
+                    </fo:block>
+                </fo:list-item-body>
+            </fo:list-item>
+        </fo:list-block>
+    </xsl:template>
+
     <!-- To be used when description is it own header -->
     <!--<xsl:template match="tei:div[@type='description']">
         <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
@@ -940,10 +961,6 @@
                 <fo:list-item-label end-indent="label-end()">
                     <fo:block font-weight="bold">
                         <xsl:value-of select="$description"/>
-                        <xsl:text> </xsl:text>
-                        <xsl:value-of select="$and"/>
-                        <xsl:text> </xsl:text>
-                        <xsl:value-of select="$usage"/>
                         <xsl:text>: </xsl:text>
                     </fo:block>
                 </fo:list-item-label>
@@ -982,11 +999,6 @@
                 <fo:list-item-label end-indent="label-end()">
                     <fo:block font-weight="bold">
                         <xsl:value-of select="$description"/>
-                        <xsl:text> </xsl:text>
-                        <xsl:value-of select="$and"/>
-                        <xsl:text> </xsl:text>
-                        <xsl:value-of select="$usage"/>
-                        <xsl:text>: </xsl:text>
                     </fo:block>
                 </fo:list-item-label>
                 <fo:list-item-body start-indent="body-start()">
@@ -1072,9 +1084,12 @@
         </fo:list-block>
     </xsl:template>
 
+    <!-- commenting these templates out, but keeping them in case they're needed again later
+    these templates should be superseded by the occurrence template...
+
     <xsl:template match="tei:div[@type='mandatory']">
-        <!-- Only value is given in the latest version of the TL -->
-        <!--<fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
+        Only value is given in the latest version of the TL 
+        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
             <fo:list-item>
                 <fo:list-item-label end-indent="label-end()">
                     <fo:block break-after="auto">
@@ -1092,13 +1107,13 @@
                     </fo:block>
                 </fo:list-item-body>
             </fo:list-item>
-        </fo:list-block>-->
-        <xsl:value-of select="."/>
+        </fo:list-block>
+        <xsl:value-of select="tei:p/text()"/>
     </xsl:template>
 
     <xsl:template match="tei:div[@type='repeatable']">
-        <!-- Only value is given in the latest layout of TL. And always after mandatory -->
-        <!--<fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
+        Only value is given in the latest layout of TL. And always after mandatory
+        <fo:list-block provisional-distance-between-starts="45mm" space-after="6pt">
             <fo:list-item>
                 <fo:list-item-label end-indent="label-end()">
                     <fo:block break-after="auto">
@@ -1116,10 +1131,10 @@
                     </fo:block>
                 </fo:list-item-body>
             </fo:list-item>
-        </fo:list-block>-->
+        </fo:list-block>
         <xsl:text>, </xsl:text>
-        <xsl:value-of select="."/>
-    </xsl:template>
+        <xsl:value-of select="tei:p/text()"/>
+    </xsl:template> -->
 
     <xsl:template match="tei:div[@type='attributes']/tei:p">
         <xsl:choose>

--- a/transformations/tagLibrary.css
+++ b/transformations/tagLibrary.css
@@ -56,6 +56,7 @@ div.leftcol {
 	padding-top: 6px;
 	padding-bottom: 6px;
 	clear:both;
+	font-weight: bold;
 }
 div.leftcolattrlist {
 	float: left;
@@ -71,6 +72,8 @@ div.example {
 	margin-left: 1%;
 	padding-top: 6px;
 	padding-bottom: 6px;
+	font-family: monospace;
+	font-size: 120%;
 }
 div.innerExample {
 	margin-left: 5%;
@@ -139,6 +142,7 @@ div.p {
 }
 .label {
 	font-weight: bold;
+	font-size: 120%;
 }
 .desc {
 	padding-top: 6px;

--- a/transformations/tagLibrary2html.xsl
+++ b/transformations/tagLibrary2html.xsl
@@ -33,88 +33,88 @@
         <xsl:variable name="toctype">short</xsl:variable><!-- Used for the look of the toc Values: long | short -->
         <xsl:param name="spaceCharacter"> </xsl:param> <!-- For egxml formatting -->       
         <xsl:variable name="bulletpoint">&#x2022;</xsl:variable>
-        <xsl:variable name="TL">PREMIS</xsl:variable> <!-- For the cases of differnt TEI used and to give the TL name in some places. EAD | EAC-CPF | EAC-G | EAC-F | PREMIS -->
+        <xsl:variable name="TL">EAD</xsl:variable> <!-- For the cases of differnt TEI used and to give the TL name in some places. EAD | EAC-CPF | EAC-G | EAC-F | PREMIS -->
 
         <!-- Headingtranslations in an own xml-file using the currentLanguage to fetch them -->
         <!-- This only works with XSLT-enginee Saxon 6.5.5 -->
         <xsl:variable name="headingtranslations" select="document('../tei/Headingtranslation.xml')"/>
         <!-- All translated headings -->
         <xsl:variable name="summary"
-                select="$headingtranslations//terms/term[@name='summary']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='summary']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="description"
-                select="$headingtranslations//terms/term[@name='description']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='description']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="mayoccurwithin"
-                select="$headingtranslations//terms/term[@name='mayoccurwithin']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='mayOccurWithin']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="mandatory"
-                select="$headingtranslations//terms/term[@name='mandatory']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='mandatory']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="optional"
-                select="$headingtranslations//terms/term[@name='optional']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='optional']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="repeatable"
-                select="$headingtranslations//terms/term[@name='repeatable']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='repeatable']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="nonrepeatable"
-                select="$headingtranslations//terms/term[@name='nonrepeatable']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='nonrepeatable']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="attributes"
-                select="$headingtranslations//terms/term[@name='attributes']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='attributes']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="references"
-                select="$headingtranslations//terms/term[@name='references']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='references']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="datatype"
-                select="$headingtranslations//terms/term[@name='datatype']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='datatype']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="toc"
-                select="$headingtranslations//terms/term[@name='toc']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='toc']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="elements"
-                select="$headingtranslations//terms/term[@name='elements']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='elements']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="maycontain"
-                select="$headingtranslations//terms/term[@name='maycontain']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='mayContain']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="occurrence"
-                select="$headingtranslations//terms/term[@name='occurrence']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='occurrence']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="appendix"
-                select="$headingtranslations//terms/term[@name='appendix']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='appendix']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="examples"
-                select="$headingtranslations//terms/term[@name='examples']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='examples']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="example"
-                select="$headingtranslations//terms/term[@name='example']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='example']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="usage"
-                select="$headingtranslations//terms/term[@name='usage']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='usage']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="and"
-                select="$headingtranslations//terms/term[@name='and']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='and']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="availability"
-                select="$headingtranslations//terms/term[@name='availability']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='availability']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="value"
-                select="$headingtranslations//terms/term[@name='value']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='value']/*:translation[@lang=$currentLanguage]"/>
                 <xsl:variable name="values"
-                select="$headingtranslations//terms/term[@name='values']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='values']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="taglibrary"
-                select="$headingtranslations//terms/term[@name='tl']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='tl']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="seealso"
-                select="$headingtranslations//terms/term[@name='seealso']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='seealso']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="attributeusage"
-                select="$headingtranslations//terms/term[@name='attributeusage']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='attributeusage']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="allrightsreserved"
-                select="$headingtranslations//terms/term[@name='allrightsreserved']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='allrightsreserved']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="printedinusa"
-                select="$headingtranslations//terms/term[@name='printedinusa']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='printedinusa']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="edition"
-                select="$headingtranslations//terms/term[@name='edition']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='edition']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="printed"
-                select="$headingtranslations//terms/term[@name='printed']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='printed']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="availableFrom"
-                select="$headingtranslations//terms/term[@name='availableFrom']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='availableFrom']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="usageNotes"
-                select="$headingtranslations//terms/term[@name='usageNotes']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='usageNotes']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="rationale"
-                select="$headingtranslations//terms/term[@name='rationale']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='rationale']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="creationMaintenance"
-                select="$headingtranslations//terms/term[@name='creationmaintenance']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='creationmaintenance']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="semanticUnit"
-                select="$headingtranslations//terms/term[@name='semanticunit']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='semanticunit']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="semanticComponents"
-                select="$headingtranslations//terms/term[@name='semanticcomponents']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='semanticcomponents']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="definition"
-                select="$headingtranslations//terms/term[@name='definition']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='definition']/*:translation[@lang=$currentLanguage]"/>
         <xsl:variable name="dataDictionary"
-                select="$headingtranslations//terms/term[@name='datadictionary']/translation[@lang=$currentLanguage]"/>        
+                select="$headingtranslations//*:terms/*:term[@name='datadictionary']/*:translation[@lang=$currentLanguage]"/>        
         <xsl:variable name="entity"
-                select="$headingtranslations//terms/term[@name='entity']/translation[@lang=$currentLanguage]"/>
+                select="$headingtranslations//*:terms/*:term[@name='entity']/*:translation[@lang=$currentLanguage]"/>
         
         <xsl:template match="/">
                 <html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
@@ -562,7 +562,7 @@
                         </xsl:otherwise>
                 </xsl:choose>
                 <div class="content">
-                        <span class="label"> &#xA0; 
+                        <span class="label"> 
                                 <xsl:value-of
                                         select="ancestor-or-self::tei:div[@type='elementDocumentation'or 'deprecatedElementDocumentation']/tei:div[@type='fullName']/tei:p"
                                 />  
@@ -651,51 +651,28 @@
                 </div>
         </xsl:template>
 
-        <xsl:template match="tei:div[@type='summary']">
-                <div class="span">
-                        <xsl:value-of select="$summary"/>
+        <xsl:template match="tei:div[@type=('summary', 'definition', 'entity', 'rationale', 'creationmaintenance', 'usagenotes', 'description')]">
+                <div class="leftcol">
+                        <xsl:variable name="termtitle"><xsl:value-of select="current()/@type"/></xsl:variable>
+                        <xsl:value-of select="$headingtranslations/*:terms/*:term[@name=$termtitle]/*:translation[@lang=$currentLanguage]"/>
                         <xsl:text>: </xsl:text>
-                        <xsl:apply-templates/>
                 </div>
+                    <div class="content">
+                        <xsl:apply-templates/>
+                    </div>
         </xsl:template>
         
-        <xsl:template match="tei:div[@type='definition']">
-                <div class="span">
-                        <xsl:value-of select="$definition"/>
+        <!-- leftcol + content elements -->
+        <xsl:template match="tei:div[@type=('mayContain', 'semanticcomponents', 'mayOccurWithin')]">
+                <div class="leftcol">
+                        <xsl:variable name="termtitle"><xsl:value-of select="current()/@type"/></xsl:variable>
+                        <xsl:value-of select="$headingtranslations/*:terms/*:term[@name=$termtitle]/*:translation[@lang=$currentLanguage]"/>
                         <xsl:text>: </xsl:text>
-                        <xsl:apply-templates/>
                 </div>
-        </xsl:template>
-        
-        <xsl:template match="tei:div[@type='entity']">
-                <div class="span">
-                        <xsl:value-of select="$entity"/>
-                        <xsl:text>: </xsl:text>
-                        <xsl:apply-templates/>
-                </div>
-        </xsl:template>
-        
-        <xsl:template match="tei:div[@type='rationale']">
-                <div class="span">
-                        <xsl:value-of select="$rationale"/>
-                        <xsl:text>: </xsl:text>
-                        <xsl:apply-templates/>
-                </div>
-        </xsl:template>
-        
-        <xsl:template match="tei:div[@type='creationmaintenance']">
-                <div class="span">
-                        <xsl:value-of select="$creationMaintenance"/>
-                        <xsl:text>: </xsl:text>
-                        <xsl:apply-templates/>
-                </div>
-        </xsl:template>
-        
-        <xsl:template match="tei:div[@type='usagenotes']">
-                <div class="span">
-                        <xsl:value-of select="$usageNotes"/>
-                        <xsl:text>: </xsl:text>
-                        <xsl:apply-templates/>
+                <div class="content">
+                        <xsl:call-template name="elemtokenize">
+                                <xsl:with-param name="text" select="tei:p"/>
+                        </xsl:call-template>
                 </div>
         </xsl:template>
 
@@ -709,21 +686,6 @@
                         <xsl:apply-templates/>
                 </div>
         </xsl:template>-->
-        
-        <!-- When we have description and usage in one header -->
-        <xsl:template match="tei:div[@type='description']">
-                <div class="span">
-                        <div class="descriptionHead">
-                                <xsl:value-of select="$description"/>
-                                <xsl:text> </xsl:text>
-                                <xsl:value-of select="$and"/>
-                                <xsl:text> </xsl:text>
-                                <xsl:value-of select="$usage"/>
-                                <xsl:text>: </xsl:text>
-                        </div>
-                        <xsl:apply-templates/>
-                </div>
-        </xsl:template>
         
         <xsl:template match="tei:div[@type='description'][parent::tei:div[@type='attributeDocumentation']]">
                 <div class="span">
@@ -752,30 +714,6 @@
                         <xsl:apply-templates/>
                 </div>
         </xsl:template>
-
-        <xsl:template match="tei:div[@type='mayContain']">
-                <div class="leftcol">
-                        <xsl:value-of select="$maycontain"/>
-                        <xsl:text>: </xsl:text>
-                </div>
-                <div class="content">
-                        <xsl:call-template name="elemtokenize">
-                                <xsl:with-param name="text" select="tei:p"/>
-                        </xsl:call-template>
-                </div>
-        </xsl:template>
-        
-        <xsl:template match="tei:div[@type='semanticcomponents']">
-                <div class="leftcol">
-                        <xsl:value-of select="$semanticComponents"/>
-                        <xsl:text>: </xsl:text>
-                </div>
-                <div class="content">
-                        <xsl:call-template name="elemtokenize">
-                                <xsl:with-param name="text" select="tei:p"/>
-                        </xsl:call-template>
-                </div>
-        </xsl:template>
         
         <xsl:template match="tei:div[@type='mayContain']" mode="dep">
                 <div class="leftcol">
@@ -784,18 +722,6 @@
                 </div>
                 <div class="content">
                         <xsl:value-of select="tei:p"/>
-                </div>
-        </xsl:template>
-
-        <xsl:template match="tei:div[@type='mayOccurWithin']">
-                <div class="leftcol">
-                        <xsl:value-of select="$mayoccurwithin"/>
-                        <xsl:text>: </xsl:text>
-                </div>
-                <div class="content">
-                        <xsl:call-template name="elemtokenize">
-                                <xsl:with-param name="text" select="tei:p"/>
-                        </xsl:call-template>
                 </div>
         </xsl:template>
         


### PR DESCRIPTION
- Removed the extra space in the Occurrence div (EAC-CPF PDF only)
- Merged some HTML divs together
- Increased the size of the element name and title in HTML
- Bolded labels in HTML
- Monospaced examples in HTML
- Condensed Description and Usage into one variable, and moved it into the generic element div