### PR TITLE
new $desc variable; adding a line about updating transformations

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -39,4 +39,5 @@ Before submitting a pull request to the [tag library repository](https://github.
 2. "Preface to Version x.y.z" has been added for the current version
 3. "(revised in x.y.z)" notes have been added to all instances across the tag library in which a changed attribute/element are listed
 4. Last version’s "(revised in x.y.z)" notes have been removed across the text
-5. PDF and HTML documents have been generated from the revised TEI document
+5. Appropriate variables and namespaces have been set in the transformation XSLT documents
+6. PDF and HTML documents have been generated from the revised TEI document

--- a/tei/Headingtranslation.xml
+++ b/tei/Headingtranslation.xml
@@ -129,6 +129,13 @@ type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
         <translation lang="de">Beispiel</translation>
         <translation lang="it">Esempio</translation>
     </term>
+    <term name="desc">
+        <translation lang="en">Description</translation>
+        <translation lang="fr">Description</translation>
+        <translation lang="gr">Περιγραφ&#942;</translation>
+        <translation lang="de">Beschreibung</translation>
+        <translation lang="it">Descrizione</translation>
+    </term>
     <term name="usage">
         <translation lang="en">Usage</translation>
         <translation lang="fr">Usage</translation>


### PR DESCRIPTION
- Created a new variable in the translations document, `$desc`, that contains the currently-unused "Description" translations.
- Added a line to UPDATING.md regarding updating variables when generating PDF/HTML tag libraries.